### PR TITLE
更新文档，添加已支持的 giscus 评论

### DIFF
--- a/docs/en/guide/README.md
+++ b/docs/en/guide/README.md
@@ -631,6 +631,7 @@ List of supported comment plugins：
 - [Remark42](https://remark42.com) : based on self-hosted service
 - [Twikoo](https://twikoo.js.org) : based on Tencent CloudBase
 - [Cusdis](https://cusdis.com) : based on third-party or self-hosted service
+- [Giscus](https://giscus.app): based on GitHub Discussion
 
 For usage and parameter setting, please click the link above to view the respective documents.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -712,6 +712,7 @@ disqus:
 - [Remark42](https://remark42.com) : 需要自托管服务端
 - [Twikoo](https://twikoo.js.org) : 基于腾讯云开发
 - [Cusdis](https://cusdis.com) : 基于第三方服务或自托管服务
+- [Giscus](https://giscus.app/zh-CN): 基于 GitHub Discussion
 
 使用方式和参数设置请点击上面链接查看各自的文档。
 


### PR DESCRIPTION
吾辈看到 https://github.com/fluid-dev/hexo-theme-fluid/pull/747 已经被合并，最新版（1.9.3）已经支持了 Giscus，但文档中却没有，所以更新一下